### PR TITLE
Added tests for string-logic

### DIFF
--- a/acid_stringlogic.yolol
+++ b/acid_stringlogic.yolol
@@ -1,0 +1,20 @@
+num=1 if "" then goto 19 end num++
+if "abc" then goto 19 end num++
+if "1" then goto 19 end num++
+if "0" then goto 19 end num++
+if not "" then goto 19 end num++
+if not "1" then goto 19 end num++
+if not "0" then goto 19 end num++
+if 1 and "" then goto 19 end num++
+if 1 and "1" then goto 19 end num++
+if 1 and "0" then goto 19 end num++
+if not (1 or "") then goto 19 end num++
+if not (1 or "1") then goto 19 end num++
+if not (1 or "0") then goto 19 end num++
+if 0 or "" then goto 19 end num++
+if 0 or "1" then goto 19 end num++
+if 0 or "0" then goto 19 end num++
+if num != 17 then :OUTPUT="Skipped: "+(17-num)+" tests" goto 20 end
+:OUTPUT="ok" goto20
+:OUTPUT="Failed test #"+num+" got: "+x+" but wanted: "+y
+goto20

--- a/acid_stringlogic.yolol
+++ b/acid_stringlogic.yolol
@@ -16,5 +16,5 @@ if 0 or "1" then goto 19 end num++
 if 0 or "0" then goto 19 end num++
 if num != 17 then :OUTPUT="Skipped: "+(17-num)+" tests" goto 20 end
 :OUTPUT="ok" goto20
-:OUTPUT="Failed test #"+num+" got: "+x+" but wanted: "+y
+:OUTPUT="Failed test #"+num
 goto20


### PR DESCRIPTION
A few test-cases for logic using strings.
In short:
- Truth-value of all strings is 0.
- ```not <string>``` returns 0 (for whatever reason...)
- ```and/or``` work as you'd expect

Successfully tested ingame.