### PR TITLE
Yolol's first bugfix

### DIFF
--- a/conformance/acid_modulus.yolol
+++ b/conformance/acid_modulus.yolol
@@ -4,10 +4,10 @@ x=10%3.1 y=0.7 if x!=y then goto19 end n++
 x=10%-3 y=1 if x!=y then goto19 end n++ 
 x=10%(-3) y=1 if x!=y then goto19 end n++ 
 x=10%-3.1 y=0.7 if x!=y then goto19 end n++
-x=10%0.7 y="error" goto19 
-n++ 
-x=10%-0.7 y="error" goto19
-n++
+x=10%0.7 y=0.2 if x!=y then goto19 end n++
+x=10%-0.7 y=0.2 if x!=y then goto19 end n++
+
+
 
 
 


### PR DESCRIPTION
A while ago they actually fixed the first bug in yolol.
```x%y``` for -1 < y < 1  does no longer throw an error.

(I tested this ingame and the changenotes didn't lie. They actually fixed this!)